### PR TITLE
Fix ERROR INVALID PATH error

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -347,7 +347,7 @@ Thank you for using this program!""")
             ), title="Select Session Data File", filetypes=(("JavaScript Object Notation", "*.json"),))
             path = d.name
         if isinstance(target, tk.Entry):
-            target.delete(0, len(self.sdpEntry.get()))
+            target.delete(0, tk.END)
             target.insert(0, path)
 
     def guisetup(self, destinations):


### PR DESCRIPTION
tk.END is more fitting here, ensuring nothing is left behind.
With the len implementation, it sometimes doesn't delete the whole entry before attempting to add a new one, leading to an error where the path name doesn't exist.